### PR TITLE
Fix of incorrect parsing multibyte strings

### DIFF
--- a/lib/Doctrine/Common/Annotations/DocParser.php
+++ b/lib/Doctrine/Common/Annotations/DocParser.php
@@ -347,8 +347,9 @@ final class DocParser
 
         // search for first valid annotation
         while (($pos = strpos($input, '@', $pos)) !== false) {
+            $preceding = substr($input, $pos - 1, 1);
             // if the @ is preceded by a space or * it is valid
-            if ($pos === 0 || $input[$pos - 1] === ' ' || $input[$pos - 1] === '*') {
+            if ($pos === 0 || in_array($preceding, array(' ', '*'))) {
                 return $pos;
             }
 


### PR DESCRIPTION
If function overloading for mb_string (http://php.net/manual/en/mbstring.overload.php) is turned on then reading of annotations with unicode strings works incorrect.
Just don't use array access for string next time :)
